### PR TITLE
Add support for Portals over the Remix API

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,3 +12,6 @@
 [submodule "garrysmod/garrysmod/addons/niknaks"]
 	path = garrysmod/garrysmod/addons/niknaks
 	url = https://github.com/Nak2/NikNaks.git
+[submodule "garrysmod/garrysmod/addons/GMod-Seamless-Portals-Remix"]
+	path = garrysmod/garrysmod/addons/GMod-Seamless-Portals-Remix
+	url = https://github.com/sambow23/GMod-Seamless-Portals-Remix.git

--- a/public/include/remix/remix_c.h
+++ b/public/include/remix/remix_c.h
@@ -805,6 +805,16 @@ extern "C" {
   typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_AutoInstancePersistentLights)(void);
   REMIXAPI remixapi_ErrorCode REMIXAPI_CALL remixapi_AutoInstancePersistentLights(void);
 
+  // Fork extension for querying the active runtime's ray-portal limits. Older
+  // runtimes do not export this function and should be treated as supporting
+  // only the stock pair.
+  typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_GetRayPortalCapabilities)(
+    uint32_t* out_maxActivePortalSurfaces,
+    uint32_t* out_maxDedicatedPortalVolumes);
+  REMIXAPI remixapi_ErrorCode REMIXAPI_CALL remixapi_GetRayPortalCapabilities(
+    uint32_t* out_maxActivePortalSurfaces,
+    uint32_t* out_maxDedicatedPortalVolumes);
+
   // Fork extension for runtime-owned mesh-instance persistence. Persistent
   // instances currently accept only the base InstanceInfo (pNext must be NULL).
   // The runtime re-submits them immediately before RTX scene preparation, so

--- a/public/include/remix/remix_c.h
+++ b/public/include/remix/remix_c.h
@@ -209,6 +209,7 @@ extern "C" {
   typedef struct remixapi_MeshHandle_T* remixapi_MeshHandle;
   typedef struct remixapi_LightHandle_T* remixapi_LightHandle;
   typedef struct remixapi_TextureHandle_T* remixapi_TextureHandle;
+  typedef uint64_t remixapi_PersistentInstanceHandle;
 
   typedef const wchar_t* remixapi_Path;
 
@@ -803,6 +804,29 @@ extern "C" {
   // Internal helper to auto-instance persistent external API lights once per frame
   typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_AutoInstancePersistentLights)(void);
   REMIXAPI remixapi_ErrorCode REMIXAPI_CALL remixapi_AutoInstancePersistentLights(void);
+
+  // Fork extension for runtime-owned mesh-instance persistence. Persistent
+  // instances currently accept only the base InstanceInfo (pNext must be NULL).
+  // The runtime re-submits them immediately before RTX scene preparation, so
+  // callers only need to send lifecycle and transform changes.
+  typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_CreatePersistentInstance)(
+    const remixapi_InstanceInfo* info,
+    remixapi_PersistentInstanceHandle* out_handle);
+  REMIXAPI remixapi_ErrorCode REMIXAPI_CALL remixapi_CreatePersistentInstance(
+    const remixapi_InstanceInfo* info,
+    remixapi_PersistentInstanceHandle* out_handle);
+
+  typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_UpdatePersistentInstance)(
+    remixapi_PersistentInstanceHandle handle,
+    const remixapi_InstanceInfo* info);
+  REMIXAPI remixapi_ErrorCode REMIXAPI_CALL remixapi_UpdatePersistentInstance(
+    remixapi_PersistentInstanceHandle handle,
+    const remixapi_InstanceInfo* info);
+
+  typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_DestroyPersistentInstance)(
+    remixapi_PersistentInstanceHandle handle);
+  REMIXAPI remixapi_ErrorCode REMIXAPI_CALL remixapi_DestroyPersistentInstance(
+    remixapi_PersistentInstanceHandle handle);
 
   // Queue a definition update for an existing analytical light. Applied safely each frame.
   typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_UpdateLightDefinition)(

--- a/source/remixapi/instance_lua_bindings.cpp
+++ b/source/remixapi/instance_lua_bindings.cpp
@@ -37,16 +37,11 @@ static void LuaToTransform(ILuaBase* LUA, int index, float outMatrix[3][4]) {
     }
 }
 
-LUA_FUNCTION(RemixInstance_DrawInstance) {
-    if (!LUA->IsType(1, Type::Table)) {
-        LUA->ThrowError("Expected table for instance info");
-        return 0;
-    }
+static bool LuaToInstanceInfo(ILuaBase* LUA, int index, remix::InstanceInfo& info) {
+    if (!LUA->IsType(index, Type::Table)) return false;
 
-    remix::InstanceInfo info;
-    
     // Mesh ID -> Handle
-    LUA->GetField(1, "meshId");
+    LUA->GetField(index, "meshId");
     if (LUA->IsType(-1, Type::Number)) {
         uint64_t meshId = (uint64_t)LUA->GetNumber(-1);
         info.mesh = RemixAPI::Instance().GetMeshManager().GetMeshHandle(meshId);
@@ -54,31 +49,90 @@ LUA_FUNCTION(RemixInstance_DrawInstance) {
     LUA->Pop();
 
     if (!info.mesh) {
-        // If no valid mesh, don't draw
-        LUA->PushBool(false);
-        return 1;
+        return false;
     }
 
     // Transform
-    LUA->GetField(1, "transform");
+    LUA->GetField(index, "transform");
     LuaToTransform(LUA, -1, info.transform.matrix);
     LUA->Pop();
 
     // Category Flags
-    LUA->GetField(1, "categoryFlags");
+    LUA->GetField(index, "categoryFlags");
     if (LUA->IsType(-1, Type::Number)) {
         info.categoryFlags = (uint32_t)LUA->GetNumber(-1);
     }
     LUA->Pop();
 
     // Double Sided
-    LUA->GetField(1, "doubleSided");
+    LUA->GetField(index, "doubleSided");
     if (LUA->IsType(-1, Type::Bool)) {
         info.doubleSided = LUA->GetBool(-1);
     }
     LUA->Pop();
 
+    return true;
+}
+
+LUA_FUNCTION(RemixInstance_DrawInstance) {
+    if (!LUA->IsType(1, Type::Table)) {
+        LUA->ThrowError("Expected table for instance info");
+        return 0;
+    }
+
+    remix::InstanceInfo info;
+    if (!LuaToInstanceInfo(LUA, 1, info)) {
+        LUA->PushBool(false);
+        return 1;
+    }
+
     bool result = RemixAPI::Instance().GetInstanceManager().DrawInstance(info);
+    LUA->PushBool(result);
+    return 1;
+}
+
+LUA_FUNCTION(RemixInstance_CreatePersistentInstance) {
+    if (!LUA->IsType(1, Type::Table)) {
+        LUA->ThrowError("Expected table for persistent instance info");
+        return 0;
+    }
+
+    remix::InstanceInfo info;
+    if (!LuaToInstanceInfo(LUA, 1, info)) {
+        LUA->PushNumber(0);
+        return 1;
+    }
+
+    remixapi_PersistentInstanceHandle handle = 0;
+    RemixAPI::Instance().GetInstanceManager().CreatePersistentInstance(info, handle);
+    LUA->PushNumber(static_cast<double>(handle));
+    return 1;
+}
+
+LUA_FUNCTION(RemixInstance_UpdatePersistentInstance) {
+    if (!LUA->IsType(1, Type::Number) || !LUA->IsType(2, Type::Table)) {
+        LUA->ThrowError("Expected persistent instance handle and instance info table");
+        return 0;
+    }
+
+    const remixapi_PersistentInstanceHandle handle =
+        static_cast<remixapi_PersistentInstanceHandle>(LUA->GetNumber(1));
+    remix::InstanceInfo info;
+    const bool result = LuaToInstanceInfo(LUA, 2, info) &&
+        RemixAPI::Instance().GetInstanceManager().UpdatePersistentInstance(handle, info);
+    LUA->PushBool(result);
+    return 1;
+}
+
+LUA_FUNCTION(RemixInstance_DestroyPersistentInstance) {
+    if (!LUA->IsType(1, Type::Number)) {
+        LUA->ThrowError("Expected persistent instance handle");
+        return 0;
+    }
+
+    const remixapi_PersistentInstanceHandle handle =
+        static_cast<remixapi_PersistentInstanceHandle>(LUA->GetNumber(1));
+    const bool result = RemixAPI::Instance().GetInstanceManager().DestroyPersistentInstance(handle);
     LUA->PushBool(result);
     return 1;
 }
@@ -91,6 +145,15 @@ void InstanceManager::InitializeLuaBindings() {
 
     m_lua->PushCFunction(RemixInstance_DrawInstance);
     m_lua->SetField(-2, "DrawInstance");
+
+    m_lua->PushCFunction(RemixInstance_CreatePersistentInstance);
+    m_lua->SetField(-2, "CreatePersistentInstance");
+
+    m_lua->PushCFunction(RemixInstance_UpdatePersistentInstance);
+    m_lua->SetField(-2, "UpdatePersistentInstance");
+
+    m_lua->PushCFunction(RemixInstance_DestroyPersistentInstance);
+    m_lua->SetField(-2, "DestroyPersistentInstance");
 
     m_lua->SetField(-2, "RemixInstance");
     m_lua->Pop();

--- a/source/remixapi/material_lua_bindings.cpp
+++ b/source/remixapi/material_lua_bindings.cpp
@@ -339,6 +339,24 @@ static remix::MaterialInfoOpaqueEXT LuaToMaterialInfoOpaqueEXT(ILuaBase* LUA, in
     return info;
 }
 
+static remix::MaterialInfoPortalEXT LuaToMaterialInfoPortalEXT(ILuaBase* LUA, int index) {
+    remix::MaterialInfoPortalEXT info;
+
+    LUA->GetField(index, "rayPortalIndex");
+    if (LUA->IsType(-1, Type::Number)) {
+        info.rayPortalIndex = static_cast<uint8_t>(LUA->GetNumber(-1));
+    }
+    LUA->Pop();
+
+    LUA->GetField(index, "rotationSpeed");
+    if (LUA->IsType(-1, Type::Number)) {
+        info.rotationSpeed = static_cast<float>(LUA->GetNumber(-1));
+    }
+    LUA->Pop();
+
+    return info;
+}
+
 // Lua function: RemixMaterial.CreateMaterial(name, materialInfo)
 LUA_FUNCTION(RemixMaterial_CreateMaterial) {
     if (!LUA->IsType(1, Type::String)) {
@@ -386,6 +404,57 @@ LUA_FUNCTION(RemixMaterial_CreateOpaqueMaterial) {
     uint64_t materialId = materialManager.CreateOpaqueMaterial(name, info, opaqueInfo);
     
     LUA->PushNumber(static_cast<double>(materialId));
+    return 1;
+}
+
+// Lua function: RemixMaterial.CreatePortalMaterial(name, materialInfo, portalInfo)
+// Uses the stock Remix API portal material extension. The stock renderer supports
+// exactly one reciprocal pair, assigned to indices 0 and 1.
+LUA_FUNCTION(RemixMaterial_CreatePortalMaterial) {
+    if (!LUA->IsType(1, Type::String) || !LUA->IsType(2, Type::Table) || !LUA->IsType(3, Type::Table)) {
+        LUA->ThrowError("CreatePortalMaterial expects name, materialInfo table, and portalInfo table");
+        return 0;
+    }
+
+    std::string name = LUA->GetString(1);
+    remix::MaterialInfo info = LuaToMaterialInfo(LUA, 2);
+    remix::MaterialInfoPortalEXT portalInfo = LuaToMaterialInfoPortalEXT(LUA, 3);
+
+    if (info.hash == 0) {
+        LUA->ThrowError("CreatePortalMaterial requires a non-zero material hash");
+        return 0;
+    }
+    if (portalInfo.rayPortalIndex >= 2) {
+        LUA->ThrowError("CreatePortalMaterial rayPortalIndex must be 0 or 1");
+        return 0;
+    }
+
+    const uint64_t materialId = RemixAPI::Instance().GetMaterialManager().CreatePortalMaterial(
+        name, info, portalInfo);
+    LUA->PushNumber(static_cast<double>(materialId));
+    return 1;
+}
+
+LUA_FUNCTION(RemixMaterial_GetPortalCapabilities) {
+    const bool supportsPersistentInstances =
+        RemixAPI::Instance().GetInstanceManager().SupportsPersistentInstances();
+    LUA->CreateTable();
+    LUA->PushBool(g_remix != nullptr);
+    LUA->SetField(-2, "available");
+    LUA->PushNumber(REMIXAPI_VERSION_MAJOR);
+    LUA->SetField(-2, "apiVersionMajor");
+    LUA->PushNumber(REMIXAPI_VERSION_MINOR);
+    LUA->SetField(-2, "apiVersionMinor");
+    LUA->PushNumber(2);
+    LUA->SetField(-2, "maxActivePortalSurfaces");
+    LUA->PushNumber(2);
+    LUA->SetField(-2, "maxDedicatedPortalVolumes");
+    LUA->PushBool(false);
+    LUA->SetField(-2, "supportsMirrors");
+    LUA->PushBool(false);
+    LUA->SetField(-2, "supportsUniformScale");
+    LUA->PushBool(supportsPersistentInstances);
+    LUA->SetField(-2, "supportsPersistentInstances");
     return 1;
 }
 
@@ -1254,6 +1323,12 @@ void MaterialManager::InitializeLuaBindings() {
     
     m_lua->PushCFunction(RemixMaterial_CreateOpaqueMaterial);
     m_lua->SetField(-2, "CreateOpaqueMaterial");
+
+    m_lua->PushCFunction(RemixMaterial_CreatePortalMaterial);
+    m_lua->SetField(-2, "CreatePortalMaterial");
+
+    m_lua->PushCFunction(RemixMaterial_GetPortalCapabilities);
+    m_lua->SetField(-2, "GetPortalCapabilities");
     
     m_lua->PushCFunction(RemixMaterial_DestroyMaterial);
     m_lua->SetField(-2, "DestroyMaterial");

--- a/source/remixapi/material_lua_bindings.cpp
+++ b/source/remixapi/material_lua_bindings.cpp
@@ -408,8 +408,8 @@ LUA_FUNCTION(RemixMaterial_CreateOpaqueMaterial) {
 }
 
 // Lua function: RemixMaterial.CreatePortalMaterial(name, materialInfo, portalInfo)
-// Uses the stock Remix API portal material extension. The stock renderer supports
-// exactly one reciprocal pair, assigned to indices 0 and 1.
+// Uses the stock Remix API portal material extension plus the active runtime's
+// queried portal-surface limit.
 LUA_FUNCTION(RemixMaterial_CreatePortalMaterial) {
     if (!LUA->IsType(1, Type::String) || !LUA->IsType(2, Type::Table) || !LUA->IsType(3, Type::Table)) {
         LUA->ThrowError("CreatePortalMaterial expects name, materialInfo table, and portalInfo table");
@@ -424,8 +424,11 @@ LUA_FUNCTION(RemixMaterial_CreatePortalMaterial) {
         LUA->ThrowError("CreatePortalMaterial requires a non-zero material hash");
         return 0;
     }
-    if (portalInfo.rayPortalIndex >= 2) {
-        LUA->ThrowError("CreatePortalMaterial rayPortalIndex must be 0 or 1");
+    uint32_t maxActivePortalSurfaces = 2;
+    uint32_t maxDedicatedPortalVolumes = 2;
+    GetRayPortalCapabilities(maxActivePortalSurfaces, maxDedicatedPortalVolumes);
+    if (portalInfo.rayPortalIndex >= maxActivePortalSurfaces) {
+        LUA->ThrowError("CreatePortalMaterial rayPortalIndex exceeds the active runtime limit");
         return 0;
     }
 
@@ -438,6 +441,10 @@ LUA_FUNCTION(RemixMaterial_CreatePortalMaterial) {
 LUA_FUNCTION(RemixMaterial_GetPortalCapabilities) {
     const bool supportsPersistentInstances =
         RemixAPI::Instance().GetInstanceManager().SupportsPersistentInstances();
+    uint32_t maxActivePortalSurfaces = 2;
+    uint32_t maxDedicatedPortalVolumes = 2;
+    const bool supportsRuntimeCapabilityQuery =
+        GetRayPortalCapabilities(maxActivePortalSurfaces, maxDedicatedPortalVolumes);
     LUA->CreateTable();
     LUA->PushBool(g_remix != nullptr);
     LUA->SetField(-2, "available");
@@ -445,10 +452,12 @@ LUA_FUNCTION(RemixMaterial_GetPortalCapabilities) {
     LUA->SetField(-2, "apiVersionMajor");
     LUA->PushNumber(REMIXAPI_VERSION_MINOR);
     LUA->SetField(-2, "apiVersionMinor");
-    LUA->PushNumber(2);
+    LUA->PushNumber(maxActivePortalSurfaces);
     LUA->SetField(-2, "maxActivePortalSurfaces");
-    LUA->PushNumber(2);
+    LUA->PushNumber(maxDedicatedPortalVolumes);
     LUA->SetField(-2, "maxDedicatedPortalVolumes");
+    LUA->PushBool(supportsRuntimeCapabilityQuery);
+    LUA->SetField(-2, "supportsRuntimeCapabilityQuery");
     LUA->PushBool(false);
     LUA->SetField(-2, "supportsMirrors");
     LUA->PushBool(false);

--- a/source/remixapi/remixapi.cpp
+++ b/source/remixapi/remixapi.cpp
@@ -23,6 +23,7 @@ using namespace GarrysMod::Lua;
 namespace RemixAPI {
 // Resolve optional Remix C API extension at runtime to avoid compile-time dependency on wrapper additions
 static PFN_remixapi_AutoInstancePersistentLights s_pfnAutoInstancePersistentLights = nullptr;
+static PFN_remixapi_GetRayPortalCapabilities s_pfnGetRayPortalCapabilities = nullptr;
 static PFN_remixapi_CreatePersistentInstance s_pfnCreatePersistentInstance = nullptr;
 static PFN_remixapi_UpdatePersistentInstance s_pfnUpdatePersistentInstance = nullptr;
 static PFN_remixapi_DestroyPersistentInstance s_pfnDestroyPersistentInstance = nullptr;
@@ -36,6 +37,8 @@ static void EnsureRemixCApiResolved() {
     if (hRemix) {
         s_pfnAutoInstancePersistentLights = reinterpret_cast<PFN_remixapi_AutoInstancePersistentLights>(
             GetProcAddress(hRemix, "remixapi_AutoInstancePersistentLights"));
+        s_pfnGetRayPortalCapabilities = reinterpret_cast<PFN_remixapi_GetRayPortalCapabilities>(
+            GetProcAddress(hRemix, "remixapi_GetRayPortalCapabilities"));
         s_pfnCreatePersistentInstance = reinterpret_cast<PFN_remixapi_CreatePersistentInstance>(
             GetProcAddress(hRemix, "remixapi_CreatePersistentInstance"));
         s_pfnUpdatePersistentInstance = reinterpret_cast<PFN_remixapi_UpdatePersistentInstance>(
@@ -44,6 +47,30 @@ static void EnsureRemixCApiResolved() {
             GetProcAddress(hRemix, "remixapi_DestroyPersistentInstance"));
         resolved = true;
     }
+}
+
+bool GetRayPortalCapabilities(uint32_t& maxActivePortalSurfaces,
+                              uint32_t& maxDedicatedPortalVolumes) {
+    maxActivePortalSurfaces = 2;
+    maxDedicatedPortalVolumes = 2;
+    EnsureRemixCApiResolved();
+    if (!s_pfnGetRayPortalCapabilities) {
+        return false;
+    }
+
+    uint32_t runtimeMaxSurfaces = 0;
+    uint32_t runtimeMaxVolumes = 0;
+    const remixapi_ErrorCode status = s_pfnGetRayPortalCapabilities(
+        &runtimeMaxSurfaces, &runtimeMaxVolumes);
+    if (status != REMIXAPI_ERROR_CODE_SUCCESS || runtimeMaxSurfaces < 2) {
+        return false;
+    }
+
+    maxActivePortalSurfaces = runtimeMaxSurfaces;
+    maxDedicatedPortalVolumes = runtimeMaxVolumes < runtimeMaxSurfaces
+        ? runtimeMaxVolumes
+        : runtimeMaxSurfaces;
+    return true;
 }
 
 //=============================================================================

--- a/source/remixapi/remixapi.cpp
+++ b/source/remixapi/remixapi.cpp
@@ -23,6 +23,9 @@ using namespace GarrysMod::Lua;
 namespace RemixAPI {
 // Resolve optional Remix C API extension at runtime to avoid compile-time dependency on wrapper additions
 static PFN_remixapi_AutoInstancePersistentLights s_pfnAutoInstancePersistentLights = nullptr;
+static PFN_remixapi_CreatePersistentInstance s_pfnCreatePersistentInstance = nullptr;
+static PFN_remixapi_UpdatePersistentInstance s_pfnUpdatePersistentInstance = nullptr;
+static PFN_remixapi_DestroyPersistentInstance s_pfnDestroyPersistentInstance = nullptr;
 
 static void EnsureRemixCApiResolved() {
     static bool resolved = false;
@@ -33,6 +36,12 @@ static void EnsureRemixCApiResolved() {
     if (hRemix) {
         s_pfnAutoInstancePersistentLights = reinterpret_cast<PFN_remixapi_AutoInstancePersistentLights>(
             GetProcAddress(hRemix, "remixapi_AutoInstancePersistentLights"));
+        s_pfnCreatePersistentInstance = reinterpret_cast<PFN_remixapi_CreatePersistentInstance>(
+            GetProcAddress(hRemix, "remixapi_CreatePersistentInstance"));
+        s_pfnUpdatePersistentInstance = reinterpret_cast<PFN_remixapi_UpdatePersistentInstance>(
+            GetProcAddress(hRemix, "remixapi_UpdatePersistentInstance"));
+        s_pfnDestroyPersistentInstance = reinterpret_cast<PFN_remixapi_DestroyPersistentInstance>(
+            GetProcAddress(hRemix, "remixapi_DestroyPersistentInstance"));
         resolved = true;
     }
 }
@@ -745,6 +754,16 @@ uint64_t MaterialManager::CreateTranslucentMaterial(const std::string& name, con
     return CreateMaterial(name, materialInfo);
 }
 
+uint64_t MaterialManager::CreatePortalMaterial(const std::string& name, const remix::MaterialInfo& info,
+                                               const remix::MaterialInfoPortalEXT& portalInfo) {
+    if (!m_remixInterface) return 0;
+
+    remix::MaterialInfo materialInfo = info;
+    materialInfo.pNext = const_cast<remix::MaterialInfoPortalEXT*>(&portalInfo);
+
+    return CreateMaterial(name, materialInfo);
+}
+
 bool MaterialManager::UpdateMaterial(uint64_t materialId, const remix::MaterialInfo& info) {
     auto it = m_materials.find(materialId);
     if (it == m_materials.end()) {
@@ -964,6 +983,52 @@ bool InstanceManager::DrawInstanceWithBones(const remix::InstanceInfo& info, con
     instanceInfo.pNext = const_cast<remix::InstanceInfoBoneTransformsEXT*>(&boneInfo);
 
     return DrawInstance(instanceInfo);
+}
+
+bool InstanceManager::SupportsPersistentInstances() {
+    EnsureRemixCApiResolved();
+    return s_pfnCreatePersistentInstance &&
+           s_pfnUpdatePersistentInstance &&
+           s_pfnDestroyPersistentInstance;
+}
+
+bool InstanceManager::CreatePersistentInstance(
+    const remix::InstanceInfo& info,
+    remixapi_PersistentInstanceHandle& outHandle) {
+    outHandle = 0;
+    if (!m_remixInterface || !SupportsPersistentInstances()) return false;
+
+    const remixapi_ErrorCode status = s_pfnCreatePersistentInstance(&info, &outHandle);
+    if (status != REMIXAPI_ERROR_CODE_SUCCESS) {
+        Warning("[InstanceManager] Failed to create persistent instance: %d\n", status);
+        outHandle = 0;
+        return false;
+    }
+    return true;
+}
+
+bool InstanceManager::UpdatePersistentInstance(
+    remixapi_PersistentInstanceHandle handle,
+    const remix::InstanceInfo& info) {
+    if (!m_remixInterface || !SupportsPersistentInstances() || handle == 0) return false;
+
+    const remixapi_ErrorCode status = s_pfnUpdatePersistentInstance(handle, &info);
+    if (status != REMIXAPI_ERROR_CODE_SUCCESS) {
+        Warning("[InstanceManager] Failed to update persistent instance: %d\n", status);
+        return false;
+    }
+    return true;
+}
+
+bool InstanceManager::DestroyPersistentInstance(remixapi_PersistentInstanceHandle handle) {
+    if (!m_remixInterface || !SupportsPersistentInstances() || handle == 0) return false;
+
+    const remixapi_ErrorCode status = s_pfnDestroyPersistentInstance(handle);
+    if (status != REMIXAPI_ERROR_CODE_SUCCESS) {
+        Warning("[InstanceManager] Failed to destroy persistent instance: %d\n", status);
+        return false;
+    }
+    return true;
 }
 
 //=============================================================================

--- a/source/remixapi/remixapi.h
+++ b/source/remixapi/remixapi.h
@@ -154,6 +154,8 @@ namespace RemixAPI {
         uint64_t CreateMaterial(const std::string& name, const remix::MaterialInfo& info);
         uint64_t CreateOpaqueMaterial(const std::string& name, const remix::MaterialInfo& info, const remix::MaterialInfoOpaqueEXT& opaqueInfo);
         uint64_t CreateTranslucentMaterial(const std::string& name, const remix::MaterialInfo& info, const remix::MaterialInfoTranslucentEXT& translucentInfo);
+        uint64_t CreatePortalMaterial(const std::string& name, const remix::MaterialInfo& info,
+                                      const remix::MaterialInfoPortalEXT& portalInfo);
         
         bool UpdateMaterial(uint64_t materialId, const remix::MaterialInfo& info);
         bool DestroyMaterial(uint64_t materialId);
@@ -233,6 +235,10 @@ namespace RemixAPI {
         bool DrawInstance(const remix::InstanceInfo& info);
         bool DrawInstanceWithBlend(const remix::InstanceInfo& info, const remix::InstanceInfoBlendEXT& blendInfo);
         bool DrawInstanceWithBones(const remix::InstanceInfo& info, const remix::InstanceInfoBoneTransformsEXT& boneInfo);
+        bool SupportsPersistentInstances();
+        bool CreatePersistentInstance(const remix::InstanceInfo& info, remixapi_PersistentInstanceHandle& outHandle);
+        bool UpdatePersistentInstance(remixapi_PersistentInstanceHandle handle, const remix::InstanceInfo& info);
+        bool DestroyPersistentInstance(remixapi_PersistentInstanceHandle handle);
         
         // Lua bindings
         void InitializeLuaBindings();

--- a/source/remixapi/remixapi.h
+++ b/source/remixapi/remixapi.h
@@ -17,6 +17,11 @@
 #include <unordered_set>
 
 namespace RemixAPI {
+    // Queries the loaded runtime's fork-specific portal limits. Returns false
+    // for stock/older runtimes and leaves the outputs at the stock pair limit.
+    bool GetRayPortalCapabilities(uint32_t& maxActivePortalSurfaces,
+                                  uint32_t& maxDedicatedPortalVolumes);
+
     // Forward declarations
     class MaterialManager;
     class MeshManager;


### PR DESCRIPTION
This includes a fork of Meetric's Seamless Portal addon as a demo, but this can be added to anything.